### PR TITLE
Multiple args for Vec3_add

### DIFF
--- a/vec3.c
+++ b/vec3.c
@@ -1,13 +1,25 @@
 #include <stdio.h>
+#include <stdarg.h>
 #include <math.h>
 #include "vec3.h"
 
-Vec3 Vec3_add(Vec3 me, Vec3 other) {
-  Vec3 result = {
-    me.x + other.x,
-    me.y + other.y,
-    me.z + other.z
-  };
+Vec3 Vec3_add(int num, ...) {
+  va_list ap;
+  va_start(ap, num);
+
+  Vec3 first = va_arg(ap, Vec3);
+  float x = first.x;
+  float y = first.y;
+  float z = first.z;
+
+  for (int i = 1; i < num; i++) {
+    Vec3 other = va_arg(ap, Vec3);
+    x += other.x;
+    y += other.y;
+    z += other.z;
+  }
+  va_end(ap);
+  Vec3 result = {x, y, z};
   return result;
 }
 

--- a/vec3.h
+++ b/vec3.h
@@ -1,13 +1,15 @@
 #ifndef VEC3_H
 #define VEC3_H
 
+#include <stdarg.h>
+
 #define COLORSPACE 255
 
 typedef struct {
   float x, y, z;
 } Vec3;
 
-Vec3 Vec3_add(Vec3 me, Vec3 other);
+Vec3 Vec3_add(int num, ...);
 Vec3 Vec3_scalarM(Vec3 vec, float scalar);
 float Vec3_len_sqd(Vec3 vec);
 float Vec3_len(Vec3 vec);


### PR DESCRIPTION
This PR resolves #1 by using the `va_list` standard from `stdarg.h`.
However, the number of input `Vec3`s will need to be specified for it to work.